### PR TITLE
add enum as keys support

### DIFF
--- a/src/main/scala/com/github/pjfanning/enumeratum/ser/EnumeratumSerializerModule.scala
+++ b/src/main/scala/com/github/pjfanning/enumeratum/ser/EnumeratumSerializerModule.scala
@@ -9,9 +9,14 @@ import enumeratum.EnumEntry
 import scala.languageFeature.postfixOps
 
 private object EnumeratumSerializer extends JsonSerializer[EnumEntry] {
-  def serialize(value: EnumEntry, jgen: JsonGenerator, provider: SerializerProvider): Unit = {
+  override def serialize(value: EnumEntry, jgen: JsonGenerator, provider: SerializerProvider): Unit =
     provider.defaultSerializeValue(value.entryName, jgen)
-  }
+
+}
+
+private object EnumeratumKeySerializer extends JsonSerializer[EnumEntry] {
+  override def serialize(value: EnumEntry, jgen: JsonGenerator, provider: SerializerProvider): Unit =
+    jgen.writeFieldName(value.entryName)
 }
 
 private object EnumeratumSerializerResolver extends Serializers.Base {
@@ -23,6 +28,16 @@ private object EnumeratumSerializerResolver extends Serializers.Base {
     else None.orNull
 }
 
+private object EnumeratumKeySerializerResolver extends Serializers.Base {
+  private val EnumEntryClass = classOf[EnumEntry]
+
+  override def findSerializer(config: SerializationConfig, javaType: JavaType, beanDesc: BeanDescription): JsonSerializer[EnumEntry] =
+    if (EnumEntryClass.isAssignableFrom(javaType.getRawClass))
+      EnumeratumKeySerializer
+    else None.orNull
+}
+
 trait EnumeratumSerializerModule extends JacksonModule {
   this += { _ addSerializers EnumeratumSerializerResolver }
+  this += { _ addKeySerializers EnumeratumKeySerializerResolver }
 }

--- a/src/test/scala/com/github/pjfanning/enumeratum/EnumeratumDeserializerSpec.scala
+++ b/src/test/scala/com/github/pjfanning/enumeratum/EnumeratumDeserializerSpec.scala
@@ -8,15 +8,19 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class EnumeratumDeserializerSpec extends AnyWordSpec with Matchers {
   "EnumeratumModule" should {
-    "deserialize Color" in {
+    "deserialize enums" in {
       val mapper = JsonMapper.builder().addModule(EnumeratumModule).build()
       val red = s""""${Color.Red.entryName}""""
+      val pear = s""""${Fruit.Pear.entryName}""""
       mapper.readValue(red, classOf[Color]) shouldEqual(Color.Red)
+      mapper.readValue(pear, classOf[Fruit]) shouldEqual(Fruit.Pear)
     }
-    "deserialize Color with non-singleton EnumeratumModule" in {
+    "deserialize enums with non-singleton EnumeratumModule" in {
       val mapper = JsonMapper.builder().addModule(new EnumeratumModule).build()
       val red = s""""${Color.Red.entryName}""""
+      val pear = s""""${Fruit.Pear.entryName}""""
       mapper.readValue(red, classOf[Color]) shouldEqual(Color.Red)
+      mapper.readValue(pear, classOf[Fruit]) shouldEqual(Fruit.Pear)
     }
     "deserialize Color (uppercase)" in {
       val mapper = JsonMapper.builder().addModule(EnumeratumModule).build()
@@ -45,11 +49,16 @@ class EnumeratumDeserializerSpec extends AnyWordSpec with Matchers {
     }
     "deserialize map with enum key" in {
       val mapper = JsonMapper.builder().addModule(DefaultScalaModule).addModule(EnumeratumModule).build()
-      val map = Map(Color.Blue -> "blue")
-      val json = mapper.writeValueAsString(map)
-      val map2 = mapper.readValue(json, new TypeReference[Map[Color, String]]{})
-      map2 should have size 1
-      map2(Color.Blue) shouldEqual "blue"
+      val colorMap = Map(Color.Blue -> "blue")
+      val fruitMap = Map(Fruit.Apple -> Color.Red, Fruit.Pear -> Color.Green, Fruit.Blueberry -> Color.Blue)
+      val colorJson = mapper.writeValueAsString(colorMap)
+      val fruitJson = mapper.writeValueAsString(fruitMap)
+      val colorMap2 = mapper.readValue(colorJson, new TypeReference[Map[Color, String]]{})
+      val fruitMap2 = mapper.readValue(fruitJson, new TypeReference[Map[Fruit, Color]]{})
+      colorMap2 should have size 1
+      colorMap2(Color.Blue) shouldEqual "blue"
+      fruitMap2 should have size 3
+      fruitMap2(Fruit.Blueberry) shouldEqual Color.Blue
     }
   }
 }

--- a/src/test/scala/com/github/pjfanning/enumeratum/EnumeratumSerializerSpec.scala
+++ b/src/test/scala/com/github/pjfanning/enumeratum/EnumeratumSerializerSpec.scala
@@ -7,13 +7,15 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class EnumeratumSerializerSpec extends AnyWordSpec with Matchers {
   "EnumeratumModule" should {
-    "serialize Color" in {
+    "serialize enums" in {
       val mapper = JsonMapper.builder().addModule(EnumeratumModule).build()
       mapper.writeValueAsString(Color.Red) shouldEqual (s""""${Color.Red.entryName}"""")
+      mapper.writeValueAsString(Fruit.Apple) shouldEqual (s""""${Fruit.Apple.entryName}"""")
     }
-    "serialize Color with non-singleton EnumeratumModule" in {
+    "serialize enums with non-singleton EnumeratumModule" in {
       val mapper = JsonMapper.builder().addModule(new EnumeratumModule).build()
       mapper.writeValueAsString(Color.Red) shouldEqual (s""""${Color.Red.entryName}"""")
+      mapper.writeValueAsString(Fruit.Apple) shouldEqual (s""""${Fruit.Apple.entryName}"""")
     }
     "serialize Ctx.Color" in {
       val mapper = JsonMapper.builder().addModule(EnumeratumModule).build()
@@ -36,6 +38,15 @@ class EnumeratumSerializerSpec extends AnyWordSpec with Matchers {
       val json2 = mapper.writeValueAsString(car2)
       json2 should include(s""""model":"${car2.model}"""")
       json2 should include(s""""color":null""")
+    }
+    "serialize map with enum key" in {
+      val mapper = JsonMapper.builder().addModule(DefaultScalaModule).addModule(EnumeratumModule).build()
+      val colorMap = Map(Color.Red -> "red")
+      val fruitMap = Map(Fruit.Apple -> Color.Red, Fruit.Pear -> Color.Green, Fruit.Blueberry -> Color.Blue)
+      val jsonColors = mapper.writeValueAsString(colorMap)
+      val jsonFruits = mapper.writeValueAsString(fruitMap)
+      jsonColors should include(s"""{"${Color.Red.entryName}":"red"}""")
+      jsonFruits should include(s"""{"${Fruit.Apple.entryName}":"${Color.Red.entryName}","${Fruit.Pear.entryName}":"${Color.Green.entryName}","${Fruit.Blueberry.entryName}":"${Color.Blue.entryName}"}""")
     }
   }
 }

--- a/src/test/scala/com/github/pjfanning/enumeratum/Fruit.scala
+++ b/src/test/scala/com/github/pjfanning/enumeratum/Fruit.scala
@@ -1,0 +1,16 @@
+package com.github.pjfanning.enumeratum
+
+import enumeratum._
+
+sealed trait Fruit extends EnumEntry
+
+object Fruit extends Enum[Fruit] {
+
+  val values = findValues
+
+  case object Apple extends Fruit
+  case object Pear extends Fruit
+  case object Blueberry extends Fruit
+
+}
+


### PR DESCRIPTION
Added support for writing and reading enumeratum values as keys in collections. Only tested with Map.

There is alot of code duplication which I'm not happy with but I was not able to come up with a clever way of abstracting common functionality. Perhaps you have a good idea?

This addresses #5 