### PR TITLE
Fix compilation using Scala 3.3.x

### DIFF
--- a/src/main/scala/com/github/pjfanning/enumeratum/deser/EnumeratumDeserializerModule.scala
+++ b/src/main/scala/com/github/pjfanning/enumeratum/deser/EnumeratumDeserializerModule.scala
@@ -28,7 +28,7 @@ private case class EnumeratumDeserializer[T <: EnumEntry](clazz: Class[T]) exten
   import EnumeratumDeserializerShared._
 
   private val clazzName = clazz.getName
-  private val enumInstance = getEnumInstance(clazzName)
+  private val enumInstance = getEnumInstance[T](clazzName)
 
   override def deserialize(p: JsonParser, ctxt: DeserializationContext): T = {
     emptyToNone(p.getValueAsString) match {


### PR DESCRIPTION
Fixes compilation error when using Sclaa 3.3.x, based on the Open Community Build failure: https://github.com/VirtusLab/community-build3/actions/runs/4650721329/jobs/8230211922 

The failure is not a bug in the compiler, but rather improvement in type inference